### PR TITLE
pipeline: fix API for the latest cwltool release 1.0.20180225105849

### DIFF
--- a/reana_workflow_engine_cwl/pipeline.py
+++ b/reana_workflow_engine_cwl/pipeline.py
@@ -99,7 +99,8 @@ class Pipeline(object):
             final_output[0] = relocateOutputs(
                 final_output[0], finaloutdir,
                 output_dirs, kwargs.get("move_outputs"),
-                kwargs["make_fs_access"](""))
+                kwargs["make_fs_access"](""),
+                kwargs["compute_checksum"])
 
         if kwargs.get("rm_tmpdir"):
             cleanIntermediate(output_dirs)

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ setup_requires = [
 ]
 
 install_requires = [
-    "cwltool",
-    "celery",
+    "cwltool==1.0.20180225105849",
+    "celery==4.1.0",
     "zmq",
 ]
 


### PR DESCRIPTION
Since the release of version 1.0.20180225105849, rebuilding `reana-workflow-engine-cwl` image with the old code will result in a runtime error. To use the image with the old code, you should change `cwltool` version in `setup.py` to be prior to this version.