### PR TITLE
installation: pin cwltool and schema-salad

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,9 @@ setup_requires = [
 ]
 
 install_requires = [
-    "cwltool",
-    "celery",
+    "cwltool==1.0.20180326152342",
+    "schema-salad==2.6.20180214144209",
+    "celery==4.1.0",
     "zmq",
 ]
 


### PR DESCRIPTION
* Pins cwltool and schema-salad to latest versions that work
  with cwl conformance tests.

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>