### PR TITLE
global: remove reana-workflow-commons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --no-cache-dir requirements-builder && \
 
 COPY . /code
 
-RUN pip install git+git://github.com/reanahub/reana-workflow-commons.git@master#egg=reana-workflow-commons
+RUN pip install git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
 
 # Debug off by default
 ARG DEBUG=false

--- a/reana_workflow_engine_cwl/tasks.py
+++ b/reana_workflow_engine_cwl/tasks.py
@@ -26,7 +26,7 @@ import json
 import logging
 
 import pika
-from reana_workflow_commons.publisher import Publisher
+from reana_commons.publisher import Publisher
 
 from reana_workflow_engine_cwl import main
 from reana_workflow_engine_cwl.celeryapp import app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 wdb
 ipdb
 Flask-DebugToolbar
-git+git://github.com/reanahub/reana-workflow-commons.git#egg=reana-workflow-commons
+git+git://github.com/reanahub/reana-commons.git#egg=reana-commons


### PR DESCRIPTION
* Removes reana-workflow-commons as a dependency as it is merged
  with reana-commons.

Connects https://github.com/reanahub/reana-workflow-commons/issues/4

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>