### PR TITLE
job-submission: always use docker

### DIFF
--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -166,12 +166,8 @@ class ReanaPipelineJob(JobBase):
         """Create job message spec to be sent to REANA-Job-Controller."""
         prettified_cmd = self.command_line[2]
         job_name = self.name
-        docker_req, docker_is_req = self.get_requirement("DockerRequirement")
-        if docker_is_req:
-            container = str(docker_req['dockerPull'])
-        else:
-            raise WorkflowException("Job {} could not be started, docker "
-                                    "requirement is missing".format(job_name))
+        docker_req, _ = self.get_requirement("DockerRequirement")
+        container = str(docker_req['dockerPull'])
         requirements_command_line = ""
         for var in self.environment:
             requirements_command_line += "export {0}=\"{1}\";".format(

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -164,7 +164,6 @@ class ReanaPipelineJob(JobBase):
 
     def create_task_msg(self, working_dir):
         """Create job message spec to be sent to REANA-Job-Controller."""
-        prettified_cmd = self.command_line[2]
         job_name = self.name
         docker_req, _ = self.get_requirement("DockerRequirement")
         container = str(docker_req['dockerPull'])
@@ -250,13 +249,12 @@ class ReanaPipelineJob(JobBase):
         wf_space_cmd += "; cp -r {0}/* {1}".format(
             self.environment['HOME'], mounted_outdir)
         wrapped_cmd = "/bin/sh -c {} ".format(pipes.quote(wf_space_cmd))
-
         create_body = {
             "experiment": "default",
             "image": container,
             "cmd": wrapped_cmd,
             "workflow_workspace": working_dir,
-            "prettified_cmd": prettified_cmd,
+            "prettified_cmd": wrapped_cmd,
             "job_name": job_name
         }
 


### PR DESCRIPTION
* Docker image has always a default value as we force it, but some
  some times the submited workflows do not require Docker even though
  we are going to always run on Docker.