### PR TITLE
Fetches experiment name from environment

### DIFF
--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -234,8 +234,9 @@ class ReanaPipelineJob(JobBase):
         wf_space_cmd += "; cp -r {0}/* {1}".format(
             self.environment['HOME'], mounted_outdir)
         wrapped_cmd = "/bin/sh -c {} ".format(pipes.quote(wf_space_cmd))
+        experiment = os.getenv("REANA_WORKFLOW_ENGINE_EXPERIMENT", "default")
         create_body = {
-            "experiment": "default",
+            "experiment": experiment,
             "image": container,
             "cmd": wrapped_cmd,
             "prettified_cmd": wrapped_cmd,


### PR DESCRIPTION
This change looks for the `REANA_WORKFLOW_ENGINE_EXPERIMENT` env variable and uses its value for the `experiment` field when creating jobs.

I'm running reana in Openshift under a non-default namespace ("reana"), and I need the jobs created in the same namespace as the volume claims.