### PR TITLE
docker: addition of nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV TERM=xterm
 RUN apt update && \
     apt install -y \
       gcc \
+      nodejs \
       vim-tiny && \
     pip install --upgrade pip
 


### PR DESCRIPTION
* Adds back Node.js dependency because `cwltool` requires it for handling
  JavaScript extensions. Necessary for running certain CWL workflows.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>