### PR TITLE
tasks: adds connectivity to job controller check

### DIFF
--- a/reana_workflow_engine_cwl/tasks.py
+++ b/reana_workflow_engine_cwl/tasks.py
@@ -16,9 +16,10 @@ import logging
 
 import click
 from reana_commons.publisher import WorkflowStatusPublisher
+from reana_commons.utils import check_connection_to_job_controller
+
 from reana_workflow_engine_cwl import main
 from reana_workflow_engine_cwl.config import LOGGING_MODULE
-
 
 log = logging.getLogger(LOGGING_MODULE)
 
@@ -54,6 +55,7 @@ def run_cwl_workflow(workflow_uuid, workflow_workspace,
     """Run cwl workflow."""
     log.info('running workflow on context: {0}'.format(locals()))
     try:
+        check_connection_to_job_controller()
         publisher = WorkflowStatusPublisher()
         main.main(workflow_uuid, workflow_json, workflow_parameters,
                   operational_options, workflow_workspace, publisher)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     'enum34>=1.1.6',
     'SQLAlchemy>=1.1.14',
     'SQLAlchemy-Utils>=0.32.18',
-    'reana-commons>=0.5.0,<0.6.0',
+    'reana-commons>=0.6.0.dev20190619,<0.7.0', 
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* When job controller and workflow engines run in the same pod,
  workflow engine has to ensure that job controller is ready to
  receive requests.
  Connects reanahub/reana-job-controller/issues/105

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>