### PR TITLE
main: allow dir to exist, necessary for restart

### DIFF
--- a/reana_workflow_engine_cwl/main.py
+++ b/reana_workflow_engine_cwl/main.py
@@ -86,9 +86,9 @@ def main(
     tmpdir = os.path.join(working_dir, "cwl/tmpdir")
     tmp_outdir = os.path.join(working_dir, "cwl/outdir")
     docker_stagedir = os.path.join(working_dir, "cwl/docker_stagedir")
-    os.makedirs(tmpdir)
-    os.makedirs(tmp_outdir)
-    os.makedirs(docker_stagedir)
+    os.makedirs(tmpdir, exist_ok=True)
+    os.makedirs(tmp_outdir, exist_ok=True)
+    os.makedirs(docker_stagedir, exist_ok=True)
     args = operational_options
 
     log.setLevel(REANA_LOG_LEVEL)


### PR DESCRIPTION
Problem:

Currently unable to restart a CWL workflow in the same workspace due to existing directories.

```
$ reana-client logs -w test-cwl-restart
==> Workflow engine logs
...
workflow failed: [Errno 17] File exists: '/var/reana/users/00000000-0000-0000-0000-000000000000/workflows/1fc4c299-36ca-410e-93aa-9336037a936a/cwl/tmpdir'
```

Fix:

With this amend running a CWL workflow does not fail if the `cwl/tmpdir`, `cwl/outdir` and `cwl/docker_stagedir` already exist.

Consequences:

If you rerun the same workflow, output files may be overwritten in `cwl/docker_outdir`. It is the users responsibility to make sure the output name is unique. 

closes reanahub/reana-server#293