### PR TITLE
global: rename job status succeeded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.7.3 (UNRELEASED)
+--------------------------
+
+- Changes workflow engine instantiation to use central REANA-Commons factory.
+- Changes status ``succeeded`` to ``finished`` to use central REANA nomenclature.
+
 Version 0.7.2 (2021-02-03)
 --------------------------
 

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -454,7 +454,7 @@ class ReanaPipelinePoll(PollThread):
 
     def is_done(self, operation):
         """Check if operation is done."""
-        terminal_states = ["succeeded", "failed"]
+        terminal_states = ["finished", "failed"]
         if operation["status"] in terminal_states:
             log.info(
                 f"[job {self.name}] FINAL JOB STATE: "
@@ -463,7 +463,7 @@ class ReanaPipelinePoll(PollThread):
             if operation["status"] != "failed":
                 self.rcode = 0
                 # here we could publish that the job with id: self.task_id
-                # succeeded or failed.
+                # finished or failed.
                 self.publisher.publish_workflow_status(
                     self.workflow_uuid,
                     1,


### PR DESCRIPTION
* Renames ``succeeded`` to ``finished`` as the latter is the one
  described centrally in ``reana_db.models.WorkflowStatus`` and
  ``reana_db.models.JobStatus``.