### PR TITLE
installation: remove legacy sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,9 +52,7 @@ scandir==1.10.0           # via cwltool
 schema-salad==4.5.20191023134839  # via cwltool, reana-workflow-engine-cwl (setup.py)
 shellescape==3.4.1        # via cwltool
 simplejson==3.17.2        # via bravado, bravado-core
-six==1.15.0               # via bravado, bravado-core, cwltool, isodate, jsonschema, mock, pathlib2, prov, pyrsistent, python-dateutil, schema-salad, sqlalchemy-utils
-sqlalchemy-utils==0.36.8  # via reana-workflow-engine-cwl (setup.py)
-sqlalchemy==1.3.18        # via reana-workflow-engine-cwl (setup.py), sqlalchemy-utils
+six==1.15.0               # via bravado, bravado-core, cwltool, isodate, jsonschema, mock, pathlib2, prov, pyrsistent, python-dateutil, schema-salad
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==2.7.3  # via bravado-core
 typing-extensions==3.7.4.2  # via bravado, cwltool, schema-salad

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ install_requires = [
     "cwltool==1.0.20191022103248",
     "schema-salad==4.5.20191023134839",
     "click>=7",
-    "SQLAlchemy>=1.3.7",
-    "SQLAlchemy-Utils>=0.34.2",
     "reana-commons>=0.7.4,<0.8.0",
 ]
 


### PR DESCRIPTION
This PR removes `sqlalchemy` and `sqlalchemy-utils` from the list of project requirements. The list of `requirements.txt` has been updated accordingly.

### Explanation
Similar to https://github.com/reanahub/reana-workflow-engine-yadage/pull/182 PR.
