### PR TITLE
k8s: allow customising job memory limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.7.5 (UNRELEASED)
+--------------------------
+
+- Adds support for specifying ``kubernetes_memory_limit`` for Kubernetes compute backend jobs.
+
 Version 0.7.4 (2021-03-23)
 --------------------------
 

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -258,6 +258,8 @@ class ReanaPipelineJob(JobBase):
         voms_proxy = self._get_hint("voms_proxy")
         htcondor_max_runtime = self._get_hint("htcondor_max_runtime")
         htcondor_accounting_group = self._get_hint("htcondor_accounting_group")
+        kubernetes_uid = self._get_hint("kubernetes_uid")
+        kubernetes_memory_limit = self._get_hint("kubernetes_memory_limit")
         create_body = {
             "image": container,
             "cmd": wrapped_cmd,
@@ -272,6 +274,8 @@ class ReanaPipelineJob(JobBase):
             "voms_proxy": voms_proxy,
             "htcondor_max_runtime": htcondor_max_runtime,
             "htcondor_accounting_group": htcondor_accounting_group,
+            "kubernetes_uid": kubernetes_uid,
+            "kubernetes_memory_limit": kubernetes_memory_limit,
         }
 
         return create_body

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -359,7 +359,7 @@ class ReanaPipelineJob(JobBase):
             log.error(
                 f"[job {self.name}] " f"Failed to submit task to job controller:\n{e}"
             )
-            return WorkflowException(e)
+            raise WorkflowException(e)
 
         def callback(rcode):
             try:


### PR DESCRIPTION
- via kubernetes_memory_limit in hint of a job

closes reanahub/reana-client#496 