### PR TITLE
models: modify  workspace_path to store full path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ The list of contributors in alphabetical order:
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Anton Khodak <https://orcid.org/0000-0003-3263-4553>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Dan Leehr <https://orcid.org/0000-0003-3221-9579>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_

--- a/reana_workflow_engine_cwl/main.py
+++ b/reana_workflow_engine_cwl/main.py
@@ -22,7 +22,7 @@ from cwltool.context import LoadingContext
 from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL, REANA_WORKFLOW_UMASK
 
 from reana_workflow_engine_cwl.__init__ import __version__
-from reana_workflow_engine_cwl.config import LOGGING_MODULE, SHARED_VOLUME_PATH
+from reana_workflow_engine_cwl.config import LOGGING_MODULE
 from reana_workflow_engine_cwl.context import REANARuntimeContext
 from reana_workflow_engine_cwl.cwl_reana import ReanaPipeline
 from reana_workflow_engine_cwl.database import SQLiteHandler
@@ -54,7 +54,6 @@ def main(
     **kwargs,
 ):
     """Run main method."""
-    working_dir = os.path.join(SHARED_VOLUME_PATH, working_dir)
     os.chdir(working_dir)
     os.umask(REANA_WORKFLOW_UMASK)
     log.info("Dumping workflow specification and input parameter files...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons
 rdflib-jsonld==0.4.0      # via schema-salad
 rdflib==4.2.2             # via cwltool, prov, rdflib-jsonld, schema-salad
-reana-commons==0.8.0a17   # via reana-workflow-engine-cwl (setup.py)
+reana-commons==0.8.0a21   # via reana-workflow-engine-cwl (setup.py)
 requests==2.25.1          # via bravado, cachecontrol, cwltool, schema-salad
 rfc3987==1.3.8            # via jsonschema
 ruamel.yaml==0.16.0       # via cwltool, schema-salad

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a5,<0.9.0",
+    "pytest-reana>=0.8.0a6,<0.9.0",
 ]
 
 extras_require = {
@@ -41,7 +41,7 @@ setup_requires = [
 install_requires = [
     "cwltool==1.0.20191022103248",
     "schema-salad==4.5.20191023134839",
-    "reana-commons>=0.8.0a17,<0.9.0",
+    "reana-commons>=0.8.0a21,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Delete the dependency on SHARED_VOLUME_PATH by storing the full path inside the database, for serial, yadage and cwl engines.

Closes reanahub/reana-db#94