### PR TITLE
docker: add --no-cache-dir to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 # Install dependencies
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install --no-cache-dir -r /code/requirements.txt
 
 # Copy cluster component source code
 WORKDIR /code


### PR DESCRIPTION
This PR disables the pip cache when installing requirements. This is a common practice when installing packages on Docker images, as it helps reduce images size. In the case of `reana-workflow-engine-cwl`, the resulting image shrink from `505` MBs to `487` MBs, ~18 MBs in total.

This optimization comes from discussion on https://github.com/reanahub/reana-server/pull/396