### PR TITLE
main: support reana hints after cwltool upgrade

### DIFF
--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -290,9 +290,10 @@ class ReanaPipelineJob(JobBase):
     def _get_hint(self, hint_name):
         """Return specific hint if specified."""
         if self.hints:
-            return self.hints[0].get(hint_name, None)
-        else:
-            return None
+            for hint in self.hints:
+                if hint_name in hint:
+                    return hint.get(hint_name)
+        return None
 
     def run(self, runtimeContext):  # noqa: C901
         """Run a job."""

--- a/reana_workflow_engine_cwl/main.py
+++ b/reana_workflow_engine_cwl/main.py
@@ -148,8 +148,6 @@ def main(
         stdout=f,
         stderr=f,
     )
+    logs = f.getvalue()
 
-    # Publish logs
-    publisher.publish_workflow_status(workflow_uuid, 2, f.getvalue())
-
-    return result
+    return result, logs

--- a/reana_workflow_engine_cwl/tasks.py
+++ b/reana_workflow_engine_cwl/tasks.py
@@ -38,7 +38,7 @@ def run_cwl_workflow_engine_adapter(
 ):
     """Run cwl workflow."""
     log.info(f"running workflow on context: {locals()}")
-    rcode = main.main(
+    rcode, logs = main.main(
         publisher,
         rjc_api_client,
         workflow_uuid,
@@ -49,7 +49,9 @@ def run_cwl_workflow_engine_adapter(
     )
     log.info("workflow done")
 
-    publisher.publish_workflow_status(workflow_uuid, rcode_to_workflow_status(rcode))
+    publisher.publish_workflow_status(
+        workflow_uuid, rcode_to_workflow_status(rcode), logs
+    )
 
 
 run_cwl_workflow = create_workflow_engine_command(


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-engine-cwl/issues/206

The internal format of parsed hints after the `cwltool` upgrade have changed. This PR addresses this issue to support `reana` hints again.

Also, running `reana-client run -f reana-cwl-slurmcern.yaml` locally created a workflow which got `finished`(instead of got `failed`), but with errors in the logs . This PR also fixes this issue by publishing the right workflow status in the end of execution.

Only thing which is unsolved is that now `cwltool` prints a warning about the unresolved `hints` that are coming from `reana`. They state this in CWL spec: https://www.commonwl.org/v1.2/Workflow.html#Requirements_and_hints

> A hint is similar to a requirement; however, it is not an error if an implementation cannot satisfy all hints. The implementation may report a warning if a hint cannot be satisfied.

So as a result we have:
```
reana ❯ rc run -f reana-cwl.yaml
==> Creating a workflow...
workflow/cwl/workflow.cwl:31:7: Warning: checking item
                                Warning:   Field `class` contains undefined reference to
                                `file:///home/amecioni/Documents/projects/reana-demo-root6-roofit/workflow/cwl/reana`
workflow/cwl/workflow.cwl:31:7: Warning: checking item
                                Warning:   Field `class` contains undefined reference to
                                `file:///home/amecioni/Documents/projects/reana-demo-root6-roofit/workflow/cwl/reana`
==> Verifying REANA specification file... /home/amecioni/Documents/projects/reana-demo-root6-roofit/reana-cwl.yaml
  -> SUCCESS: Valid REANA specification file.
==> Verifying dangerous workflow operations...
  -> SUCCESS: Workflow operations appear valid.
workflow.37
==> Uploading files...
...
```
Same warnings appear in the logs