### PR TITLE
add kubernetes_job_timeout parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.1 (UNRELEASED)
+---------------------------
+
+- Adds support for specifying ``kubernetes_job_timeout`` for Kubernetes compute backend jobs.
+
 Version 0.8.0 (2021-11-22)
 --------------------------
 

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -260,6 +260,7 @@ class ReanaPipelineJob(JobBase):
         htcondor_accounting_group = self._get_hint("htcondor_accounting_group")
         kubernetes_uid = self._get_hint("kubernetes_uid")
         kubernetes_memory_limit = self._get_hint("kubernetes_memory_limit")
+        kubernetes_job_timeout = self._get_hint("kubernetes_job_timeout")
         create_body = {
             "image": container,
             "cmd": wrapped_cmd,
@@ -276,6 +277,7 @@ class ReanaPipelineJob(JobBase):
             "htcondor_accounting_group": htcondor_accounting_group,
             "kubernetes_uid": kubernetes_uid,
             "kubernetes_memory_limit": kubernetes_memory_limit,
+            "kubernetes_job_timeout": kubernetes_job_timeout,
         }
 
         return create_body

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,56 +7,56 @@
 amqp==2.6.1               # via kombu
 appdirs==1.4.4            # via fs
 argcomplete==1.12.3       # via cwltool
-attrs==21.2.0             # via jsonschema
+attrs==21.4.0             # via jsonschema
 bagit==1.8.1              # via cwltool
 bravado-core==5.17.0      # via bravado
 bravado==10.3.2           # via reana-commons
-cachecontrol==0.12.6      # via schema-salad
-certifi==2021.5.30        # via requests
-charset-normalizer==2.0.6  # via requests
+cachecontrol==0.12.10     # via schema-salad
+certifi==2021.10.8        # via requests
+charset-normalizer==2.0.10  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.0.1              # via reana-commons
+click==8.0.3              # via reana-commons
 coloredlogs==15.0.1       # via cwltool
 cwltool==3.1.20210628163208  # via reana-workflow-engine-cwl (setup.py)
-fs==2.4.13                # via reana-commons
+fs==2.4.14                # via reana-commons
 humanfriendly==10.0       # via coloredlogs
-idna==3.2                 # via jsonschema, requests
-isodate==0.6.0            # via rdflib
-jsonpointer==2.1          # via jsonschema
+idna==3.3                 # via jsonschema, requests
+isodate==0.6.1            # via rdflib
+jsonpointer==2.2          # via jsonschema
 jsonref==0.2              # via bravado-core
 jsonschema[format]==3.2.0  # via bravado-core, reana-commons
 kombu==4.6.11             # via reana-commons
 lockfile==0.12.2          # via schema-salad
-lxml==4.6.3               # via prov
+lxml==4.7.1               # via prov
 mistune==0.8.4            # via schema-salad
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack-python==0.5.6     # via bravado
-msgpack==1.0.2            # via bravado-core, cachecontrol
+msgpack==1.0.3            # via bravado-core, cachecontrol
 mypy-extensions==0.4.3    # via cwltool
 networkx==2.6.3           # via prov
 prov==1.5.1               # via cwltool
-psutil==5.8.0             # via cwltool
+psutil==5.9.0             # via cwltool
 pydot==1.4.2              # via cwltool
 pyparsing==2.4.7          # via pydot, rdflib
-pyrsistent==0.18.0        # via jsonschema
+pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, prov
 pytz==2021.3              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons==0.8.0	# via reana-workflow-engine-cwl (setup.py)
-requests==2.26.0          # via bravado, cachecontrol, cwltool, schema-salad
+reana-commons==0.8.1      # via reana-workflow-engine-cwl (setup.py)
+requests==2.27.1          # via bravado, cachecontrol, cwltool, schema-salad
 rfc3987==1.3.8            # via jsonschema
 ruamel.yaml.clib==0.2.6   # via ruamel.yaml
 ruamel.yaml==0.17.10      # via cwltool, schema-salad
-schema-salad==8.2.20210918131710  # via cwltool
+schema-salad==8.2.20220103095339  # via cwltool
 shellescape==3.8.1        # via cwltool
-simplejson==3.17.5        # via bravado, bravado-core
+simplejson==3.17.6        # via bravado, bravado-core
 six==1.16.0               # via bravado, bravado-core, fs, isodate, jsonschema, mock, prov, python-dateutil, rdflib
 strict-rfc3339==0.7       # via jsonschema
-swagger-spec-validator==2.7.3  # via bravado-core
+swagger-spec-validator==2.7.4  # via bravado-core
 typing-extensions==3.10.0.2  # via bravado, cwltool
-urllib3==1.26.7           # via requests
+urllib3==1.26.8           # via requests
 vine==1.3.0               # via amqp
 webcolors==1.11.1         # via jsonschema
 werkzeug==2.0.2           # via reana-commons


### PR DESCRIPTION
closes reanahub/reana-job-controller#343

How to test:

This PR is part of a bigger group of PRs. Please refer to the addressed issue to see all of them.

1. Modify CWL helloworld example, with `kubernetes_job_timeout=20` (in seconds) and `sleeptime=2` (2 seconds so the workflow will definitely run longer than 20 seconds):

`workflow/cwl/helloworld-job.yml`
```yaml
sleeptime: 2
...
```

`workflow/cwl/helloworld.cwl`
```yaml
...
steps:
  first:
    hints:
      reana:
        kubernetes_job_timeout: 20  # <= here
    run: helloworld.tool
...
```

2. Start workflow `reana-client run -w cwl-timeout -f reana-cwl.yaml`

3. After 25-30 seconds, check using `reana-client list` if workflow failed. It should.

4. Using `reana-client logs` check if the reason is `Job was killed due to timeout.`

5. Try to input string or object instead of integer for `kubernetes_job_timeout`, the workflow should fail and have logs indicating that. This will not work right now due to [this issue](https://github.com/reanahub/reana-workflow-controller/issues/426). It will be fixed after this PR.
