### PR TITLE
docs: add .readthedocs.yaml to migrate to RTD v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# This file is part of REANA.
+# Copyright (C) 2023 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ include scripts/*.py
 include docs/requirements.txt
 include Dockerfile
 include .dockerignore
+exclude .readthedocs.yaml
 prune docs/_build
 recursive-include badges *.json
 recursive-include docs *.py

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "ipdb",
         "Flask-DebugToolbar",
     ],
-    "docs": ["Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9"],
+    "docs": ["Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9", "Jinja2<3.1"],
     "tests": tests_require,
 }
 


### PR DESCRIPTION
Closes reanahub/reana#710.