### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,186 +4,19 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
 jobs:
-  lint-commitlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
-
-      - name: Check commit message compliance of the recently pushed commit
-        if: github.event_name == 'push'
-        run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
-
-      - name: Check commit message compliance of the pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
-
-  lint-shellcheck:
+  docker-build:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Runs shell script static analysis
-        run: |
-          sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
-
-  lint-black:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python code formatting
-        run: |
-          pip install --upgrade pip
-          pip install black
-          ./run-tests.sh --check-black
-
-  lint-flake8:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with pep8, pyflakes and circular complexity
-        run: |
-          pip install --upgrade pip
-          pip install flake8
-          ./run-tests.sh --check-flake8
-
-  lint-pydocstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with Python docstring conventions
-        run: |
-          pip install --upgrade pip
-          pip install pydocstyle
-          ./run-tests.sh --check-pydocstyle
-
-  lint-check-manifest:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python manifest completeness
-        run: |
-          pip install --upgrade pip
-          pip install check-manifest
-          ./run-tests.sh --check-manifest
-
-  lint-jsonlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Lint JSON files
-        run: |
-          npm install jsonlint --global
-          ./run-tests.sh --check-jsonlint
-
-  lint-markdownlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Lint Markdown files
-        run: |
-          npm install markdownlint-cli2 --global
-          ./run-tests.sh --check-markdownlint
-
-  format-shfmt:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check shell script code formatting
-        run: |
-          sudo apt-get install shfmt
-          ./run-tests.sh --check-shfmt
-
-  format-prettier:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Check Prettier code fomatting
-        run: |
-          npm install prettier --global
-          ./run-tests.sh --check-prettier
-
-  lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --check-yamllint
+      - name: Build Docker image
+        run: ./run-tests.sh --docker-build
 
   docs-sphinx:
     runs-on: ubuntu-24.04
@@ -208,7 +41,192 @@ jobs:
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
+        run: ./run-tests.sh --docs-sphinx
+
+  format-black:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python code formatting
+        run: |
+          pip install --upgrade pip
+          pip install black
+          ./run-tests.sh --format-black
+
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code fomatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
+  lint-commitlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Check commit message compliance of the recently pushed commit
+        if: github.event_name == 'push'
+        run: |
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
+
+      - name: Check commit message compliance of the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+
+  lint-flake8:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with pep8, pyflakes and circular complexity
+        run: |
+          pip install --upgrade pip
+          pip install flake8
+          ./run-tests.sh --lint-flake8
+
+  lint-hadolint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Dockerfile compliance
+        run: ./run-tests.sh --lint-hadolint
+
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
+  lint-manifest:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python manifest completeness
+        run: |
+          pip install --upgrade pip
+          pip install check-manifest
+          ./run-tests.sh --lint-manifest
+
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
+  lint-pydocstyle:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with Python docstring conventions
+        run: |
+          pip install --upgrade pip
+          pip install pydocstyle
+          ./run-tests.sh --lint-pydocstyle
+
+  lint-shellcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runs shell script static analysis
+        run: |
+          sudo apt-get install shellcheck
+          ./run-tests.sh --lint-shellcheck
+
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
 
   python-tests:
     runs-on: ubuntu-24.04
@@ -228,7 +246,7 @@ jobs:
           pip install -e .[all]
 
       - name: Run pytest
-        run: ./run-tests.sh --check-pytest
+        run: ./run-tests.sh --python-tests
 
       - name: Codecov Coverage
         uses: codecov/codecov-action@v4
@@ -236,38 +254,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 
-  lint-dockerfile:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check Dockerfile compliance
-        run: ./run-tests.sh --check-dockerfile
-
-  docker-build:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build Docker image
-        run: ./run-tests.sh --check-docker-build
-
   release-docker:
     runs-on: ubuntu-24.04
     if: >
       vars.RELEASE_DOCKER == 'true' && github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
+      - docker-build
       - docs-sphinx
-      - lint-black
-      - lint-check-manifest
+      - format-black
+      - format-prettier
+      - format-shfmt
       - lint-commitlint
-      - lint-dockerfile
       - lint-flake8
+      - lint-hadolint
+      - lint-jsonlint
+      - lint-manifest
+      - lint-markdownlint
       - lint-pydocstyle
       - lint-shellcheck
+      - lint-yamllint
       - python-tests
     steps:
       - name: Release Docker image

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,5 @@
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
-
-# Allow multiple headings with same content (for different releases)
-MD024: false
+# Allow duplicate headings under different parent sections (e.g. CWL v1.1/v1.2)
+MD024:
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD024 -->
 
 # Changelog
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,35 @@
 set -o errexit
 set -o nounset
 
-check_commitlint() {
+docker_build() {
+    docker build -t docker.io/reanahub/reana-workflow-engine-cwl .
+}
+
+docs_sphinx() {
+    sphinx-build -qnNW docs docs/_build/html
+}
+
+format_black() {
+    black --check .
+}
+
+format_prettier() {
+    prettier -c .
+}
+
+format_shfmt() {
+    shfmt -d .
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,102 +67,105 @@ check_commitlint() {
     fi
 }
 
-check_shellcheck() {
-    find . -name "*.sh" -exec shellcheck {} \+
-}
-
-check_pydocstyle() {
-    pydocstyle reana_workflow_engine_cwl
-}
-
-check_black() {
-    black --check .
-}
-
-check_flake8() {
+lint_flake8() {
     flake8 .
 }
 
-check_manifest() {
-    check-manifest
-}
-
-check_sphinx() {
-    sphinx-build -qnNW docs docs/_build/html
-}
-
-check_pytest() {
-    pytest
-}
-
-check_dockerfile() {
+lint_hadolint() {
     docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
-check_docker_build() {
-    docker build -t docker.io/reanahub/reana-workflow-engine-cwl .
-}
-
-check_jsonlint() {
+lint_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
-check_yamllint() {
-    yamllint .
+lint_manifest() {
+    check-manifest
 }
 
-check_shfmt() {
-    shfmt -d .
-}
-
-check_markdownlint() {
+lint_markdownlint() {
     markdownlint-cli2 "**/*.md"
 }
 
-check_prettier() {
-    prettier -c .
+lint_pydocstyle() {
+    pydocstyle reana_workflow_engine_cwl
 }
 
-check_all() {
-    check_commitlint
-    check_shellcheck
-    check_pydocstyle
-    check_black
-    check_flake8
-    check_manifest
-    check_sphinx
-    check_pytest
-    check_dockerfile
-    check_docker_build
-    check_jsonlint
-    check_yamllint
-    check_shfmt
-    check_markdownlint
-    check_prettier
+lint_shellcheck() {
+    find . -name "*.sh" -exec shellcheck {} \+
+}
+
+lint_yamllint() {
+    yamllint .
+}
+
+python_tests() {
+    pytest
+}
+
+all() {
+    docker_build
+    docs_sphinx
+    format_black
+    format_prettier
+    format_shfmt
+    lint_commitlint
+    lint_flake8
+    lint_hadolint
+    lint_jsonlint
+    lint_manifest
+    lint_markdownlint
+    lint_pydocstyle
+    lint_shellcheck
+    lint_yamllint
+    python_tests
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all                  Perform all checks [default]"
+    echo "  --docker-build         Check Docker build"
+    echo "  --docs-sphinx          Check Sphinx docs build"
+    echo "  --format-black         Check formatting of Python code"
+    echo "  --format-prettier      Check formatting of Markdown etc files"
+    echo "  --format-shfmt         Check formatting of shell scripts"
+    echo "  --help                 Display this help message"
+    echo "  --lint-commitlint      Check linting of commit messages"
+    echo "  --lint-flake8          Check linting of Python code"
+    echo "  --lint-hadolint        Check linting of Dockerfiles"
+    echo "  --lint-jsonlint        Check linting of JSON files"
+    echo "  --lint-manifest        Check linting of Python manifest"
+    echo "  --lint-markdownlint    Check linting of Markdown files"
+    echo "  --lint-pydocstyle      Check linting of Python docstrings"
+    echo "  --lint-shellcheck      Check linting of shell scripts"
+    echo "  --lint-yamllint        Check linting of YAML files"
+    echo "  --python-tests         Check Python test suite"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
---check-commitlint) check_commitlint "$@" ;;
---check-shellcheck) check_shellcheck ;;
---check-pydocstyle) check_pydocstyle ;;
---check-black) check_black ;;
---check-flake8) check_flake8 ;;
---check-manifest) check_manifest ;;
---check-sphinx) check_sphinx ;;
---check-pytest) check_pytest ;;
---check-dockerfile) check_dockerfile ;;
---check-docker-build) check_docker_build ;;
---check-jsonlint) check_jsonlint ;;
---check-yamllint) check_yamllint ;;
---check-shfmt) check_shfmt ;;
---check-markdownlint) check_markdownlint ;;
---check-prettier) check_prettier ;;
---check-all) check_all ;;
-*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
+--all) all ;;
+--help) help ;;
+--docker-build) docker_build ;;
+--docs-sphinx) docs_sphinx ;;
+--format-black) format_black ;;
+--format-prettier) format_prettier ;;
+--format-shfmt) format_shfmt ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-flake8) lint_flake8 ;;
+--lint-hadolint) lint_hadolint ;;
+--lint-jsonlint) lint_jsonlint ;;
+--lint-manifest) lint_manifest ;;
+--lint-markdownlint) lint_markdownlint ;;
+--lint-pydocstyle) lint_pydocstyle ;;
+--lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
+--python-tests) python_tests ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.