### PR TITLE
refactor(pytest): drop pytest-reana and use pytest directly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_workflow_engine_cwl --cov-report=term-missing --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_workflow_engine_cwl --cov-report=term-missing --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, prov
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, reana-commons, swagger-spec-validator
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl]==0.95.0a14  # via reana-workflow-engine-cwl (setup.py)
+reana-commons[cwl]==0.95.0a16	# via reana-workflow-engine-cwl (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
 requests==2.33.0          # via bravado, bravado-core, cachecontrol, cwltool, schema-salad
 rfc3339-validator==0.1.4  # via jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,72 +7,71 @@
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs
 argcomplete==3.6.3        # via cwltool
-arrow==1.4.0              # via isoduration
-attrs==26.1.0             # via jsonschema, referencing
+attrs==26.1.0             # via jsonschema
 bagit==1.9.0              # via cwltool
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
 cachecontrol[filecache]==0.14.4  # via cachecontrol, schema-salad
-certifi==2026.2.25        # via requests
-charset-normalizer==3.4.6  # via requests
+certifi==2026.4.22        # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.3.1              # via reana-commons
+click==8.3.3              # via reana-commons
 coloredlogs==15.0.1       # via cwltool
 cwltool==3.1.20210628163208  # via reana-commons
-filelock==3.25.2          # via cachecontrol
-fqdn==1.5.1               # via jsonschema
+filelock==3.29.0          # via cachecontrol
 fs==2.4.16                # via reana-commons
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 humanfriendly==10.0       # via coloredlogs
-idna==3.11                # via jsonschema, requests
-importlib-resources==6.5.2  # via swagger-spec-validator
+idna==3.14                # via jsonschema, requests
+importlib-resources==7.1.0  # via swagger-spec-validator
 isodate==0.7.2            # via rdflib
-isoduration==20.11.0      # via jsonschema
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
-jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
-jsonschema-specifications==2025.9.1  # via jsonschema
+jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.6.2              # via reana-commons
-lxml==6.0.2               # via prov
+lxml==6.1.0               # via prov
+markdown-it-py==4.2.0     # via rich
 markupsafe==3.0.3         # via werkzeug
-mistune==3.1.4            # via schema-salad
+mdurl==0.1.2              # via markdown-it-py
+mistune==3.2.1            # via schema-salad
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core, cachecontrol
 msgpack-python==0.5.6     # via bravado
 mypy-extensions==1.1.0    # via cwltool, schema-salad
 networkx==3.6.1           # via prov
-packaging==26.0           # via kombu
-parse==1.21.1             # via reana-commons
+packaging==26.2           # via kombu
+parse==1.22.0             # via reana-commons
 prov==1.5.1               # via cwltool
 psutil==7.2.2             # via cwltool
 pydot==4.0.1              # via cwltool
+pygments==2.20.0          # via rich
 pyparsing==3.3.2          # via pydot, rdflib
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, prov
-pytz==2026.1.post1        # via bravado-core
+pyrsistent==0.20.0        # via jsonschema
+python-dateutil==2.9.0.post0  # via bravado, bravado-core, prov
+pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, reana-commons, swagger-spec-validator
 rdflib==5.0.0             # via cwltool, prov, schema-salad
-reana-commons[cwl]==0.95.0a16	# via reana-workflow-engine-cwl (setup.py)
-referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.0          # via bravado, bravado-core, cachecontrol, cwltool, schema-salad
-rfc3339-validator==0.1.4  # via jsonschema
+reana-commons[cwl]==0.95.0a16  # via reana-workflow-engine-cwl (setup.py)
+requests==2.34.0          # via bravado, bravado-core, cachecontrol, cwltool, schema-salad
 rfc3987==1.3.8            # via jsonschema
-rpds-py==0.30.0           # via jsonschema, referencing
+rich==15.0.0              # via rich-argparse
+rich-argparse==1.8.0      # via schema-salad
 ruamel-yaml==0.17.10      # via cwltool, schema-salad
-schema-salad==8.9.20251102115403  # via cwltool
+schema-salad==8.9.20260417192335  # via cwltool
 shellescape==3.8.1        # via cwltool
-simplejson==3.20.2        # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, mock, prov, python-dateutil, rdflib, rfc3339-validator
+simplejson==4.1.1         # via bravado, bravado-core
+six==1.17.0               # via bravado, bravado-core, fs, jsonschema, mock, prov, python-dateutil, rdflib
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via bravado, cwltool, gherkin-official, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via requests
+typing-extensions==4.15.0  # via bravado, cwltool, gherkin-official, swagger-spec-validator
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema
-werkzeug==3.1.7           # via reana-commons
+werkzeug==3.1.8           # via reana-commons
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ extras_require = {
     ],
     "docs": ["myst-parser", "Sphinx>=1.4.4", "sphinx-rtd-theme>=0.1.9", "Jinja2<3.1"],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "pytest>=7.0.0,<9.0.0",
+        "pytest-cov>=3.0.0,<4.0",
     ],
 }
 
@@ -37,7 +38,7 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "reana-commons[cwl]>=0.95.0a14,<0.96.0",
+    "reana-commons[cwl]>=0.95.0a16,<0.96.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
This engine never used any fixture from pytest-reana; the dependency
only pulled pytest and friends transitively. Replace it with direct
pytest usage.

Closes https://github.com/reanahub/pytest-reana/issues/156