### PR TITLE
fix(cwl_reana): preserve staged inputs during output copy

### DIFF
--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -160,6 +160,39 @@ class ReanaPipelineJob(JobBase):
                     with os.fdopen(fd, "wb") as f:
                         f.write(vol.resolved.encode("utf-8"))
 
+    def _initial_workdir_symlink_cleanup_command(self):
+        """Build a command that unlinks staged inputs before copying outputs."""
+        generatemapper = getattr(self, "generatemapper", None)
+        if not generatemapper:
+            return ""
+
+        container_outdir = self.builder.outdir.rstrip("/")
+        target_prefix = container_outdir + "/"
+        host_outdir = os.path.abspath(self.outdir)
+        cleanup_command = ""
+        for _, volume in generatemapper.items():
+            is_linked_type = volume.type in ("File", "Directory") or (
+                self.inplace_update
+                and volume.type in ("WritableFile", "WritableDirectory")
+            )
+            if (
+                not volume.staged
+                or not is_linked_type
+                or volume.resolved.startswith("_:")
+                or not volume.target.startswith(target_prefix)
+            ):
+                continue
+
+            relative_target = volume.target[len(target_prefix) :]
+            host_target = os.path.abspath(os.path.join(host_outdir, relative_target))
+            if os.path.commonpath([host_outdir, host_target]) != host_outdir:
+                continue
+            quoted_target = shellescape.quote(host_target)
+            cleanup_command += f"; if [ -L {quoted_target} ]; then "
+            cleanup_command += f"rm -f {quoted_target}; fi"
+
+        return cleanup_command
+
     def create_task_msg(self, working_dir, workflow_uuid):  # noqa: C901
         """Create job message spec to be sent to REANA-Job-Controller."""
         job_name = self.name
@@ -247,6 +280,7 @@ class ReanaPipelineJob(JobBase):
         docker_req, _ = self.get_requirement("DockerRequirement")
         if docker_req:
             docker_output_dir = docker_req.get("dockerOutputDirectory", None)
+        wf_space_cmd += self._initial_workdir_symlink_cleanup_command()
         if docker_output_dir:
             wf_space_cmd = (
                 f"mkdir -p {docker_output_dir} && {wf_space_cmd}"

--- a/reana_workflow_engine_cwl/cwl_reana.py
+++ b/reana_workflow_engine_cwl/cwl_reana.py
@@ -171,13 +171,9 @@ class ReanaPipelineJob(JobBase):
         host_outdir = os.path.abspath(self.outdir)
         cleanup_command = ""
         for _, volume in generatemapper.items():
-            is_linked_type = volume.type in ("File", "Directory") or (
-                self.inplace_update
-                and volume.type in ("WritableFile", "WritableDirectory")
-            )
             if (
                 not volume.staged
-                or not is_linked_type
+                or volume.type not in ("File", "Directory")
                 or volume.resolved.startswith("_:")
                 or not volume.target.startswith(target_prefix)
             ):

--- a/tests/test_cwl_reana.py
+++ b/tests/test_cwl_reana.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA CWL job tests."""
+
+import subprocess
+from types import SimpleNamespace
+
+import shellescape
+
+from reana_workflow_engine_cwl.cwl_reana import ReanaPipelineJob
+
+
+def test_initial_workdir_input_is_not_overwritten_during_copy(tmp_path):
+    """Unlink a staged input before copying an output with the same name."""
+    uploaded_input = tmp_path / "workspace" / "gendata.C"
+    uploaded_input.parent.mkdir()
+    uploaded_input.write_text("uploaded input")
+
+    outdir = tmp_path / "cwl" / "outdir"
+    outdir.mkdir(parents=True)
+    staged_input = outdir / uploaded_input.name
+    staged_input.symlink_to(uploaded_input)
+
+    container_outdir = "/var/lib/cwl/job"
+    job = object.__new__(ReanaPipelineJob)
+    job.builder = SimpleNamespace(outdir=container_outdir)
+    job.generatemapper = {
+        "input": SimpleNamespace(
+            staged=True,
+            type="File",
+            resolved=str(uploaded_input),
+            target=f"{container_outdir}/{uploaded_input.name}",
+        )
+    }
+    job.inplace_update = False
+    job.outdir = str(outdir)
+
+    generated_output = tmp_path / "job-output"
+    generated_output.mkdir()
+    (generated_output / uploaded_input.name).write_text("generated output")
+
+    cleanup_command = job._initial_workdir_symlink_cleanup_command()
+    command = (
+        f"true{cleanup_command}; cp -r "
+        f"{shellescape.quote(str(generated_output))}/* "
+        f"{shellescape.quote(str(outdir))}"
+    )
+    subprocess.run(["/bin/sh", "-c", command], check=True)
+
+    assert uploaded_input.read_text() == "uploaded input"
+    assert not staged_input.is_symlink()
+    assert staged_input.read_text() == "generated output"

--- a/tests/test_cwl_reana.py
+++ b/tests/test_cwl_reana.py
@@ -16,16 +16,20 @@ import shellescape
 from reana_workflow_engine_cwl.cwl_reana import ReanaPipelineJob
 
 
-def test_initial_workdir_input_is_not_overwritten_during_copy(tmp_path):
-    """Unlink a staged input before copying an output with the same name."""
+def test_initial_workdir_cleanup_preserves_inplace_update_symlinks(tmp_path):
+    """Unlink staged inputs while preserving intentional writable symlinks."""
     uploaded_input = tmp_path / "workspace" / "gendata.C"
     uploaded_input.parent.mkdir()
     uploaded_input.write_text("uploaded input")
+    writable_input = uploaded_input.parent / "writable.txt"
+    writable_input.write_text("writable input")
 
     outdir = tmp_path / "cwl" / "outdir"
     outdir.mkdir(parents=True)
     staged_input = outdir / uploaded_input.name
     staged_input.symlink_to(uploaded_input)
+    staged_writable_input = outdir / writable_input.name
+    staged_writable_input.symlink_to(writable_input)
 
     container_outdir = "/var/lib/cwl/job"
     job = object.__new__(ReanaPipelineJob)
@@ -36,9 +40,15 @@ def test_initial_workdir_input_is_not_overwritten_during_copy(tmp_path):
             type="File",
             resolved=str(uploaded_input),
             target=f"{container_outdir}/{uploaded_input.name}",
-        )
+        ),
+        "writable_input": SimpleNamespace(
+            staged=True,
+            type="WritableFile",
+            resolved=str(writable_input),
+            target=f"{container_outdir}/{writable_input.name}",
+        ),
     }
-    job.inplace_update = False
+    job.inplace_update = True
     job.outdir = str(outdir)
 
     generated_output = tmp_path / "job-output"
@@ -56,3 +66,5 @@ def test_initial_workdir_input_is_not_overwritten_during_copy(tmp_path):
     assert uploaded_input.read_text() == "uploaded input"
     assert not staged_input.is_symlink()
     assert staged_input.read_text() == "generated output"
+    assert staged_writable_input.is_symlink()
+    assert staged_writable_input.read_text() == "writable input"


### PR DESCRIPTION
Unlink only the input symlinks created for InitialWorkDirRequirement immediately before copying job outputs into the CWL outdir.

Prevent output copying from following destination symlinks and overwriting uploaded inputs, with a regression test reproducing the intermittent failure.

Closes reanahub/reana-workflow-engine-cwl#321